### PR TITLE
use std::size_t and generate binary .aig output

### DIFF
--- a/btor2/btorasaig.py
+++ b/btor2/btorasaig.py
@@ -13,7 +13,7 @@ verbose = True
 def modify_input_file(filepath):
     if verbose:
         print(f"Modifying input file: {filepath}")
-    btor2aiger_cmd = btor2aig_path + " " + filepath + " -a > " + filepath + ".aig"
+    btor2aiger_cmd = btor2aig_path + " " + filepath + " > " + filepath + ".aig"
     try:
         subprocess.run(btor2aiger_cmd, shell=True)
     except Exception as e:

--- a/src/model/DAGCNFSimplifier.h
+++ b/src/model/DAGCNFSimplifier.h
@@ -26,7 +26,7 @@ class DAGCNFSimplifier {
     struct Occur {
         std::vector<int> occur;
         bool dirty = false;
-        size_t size = 0;
+        std::size_t size = 0;
     };
 
     int m_maxVar = 0;
@@ -69,14 +69,14 @@ class DAGCNFSimplifier {
 
     void OccurAdd(int lit, int clause_id);
     void OccurDel(int lit, int clause_id);
-    size_t OccurNum(int lit) const;
+    std::size_t OccurNum(int lit) const;
     const std::vector<int> &OccurGet(int lit);
     void OccurClean(int lit);
 
     bool TryResolvent(const std::vector<int> &pcnf,
                       const std::vector<int> &ncnf,
                       int pivot_var,
-                      size_t limit,
+                      std::size_t limit,
                       std::vector<clause> &out);
 
     void Eliminate(int var);


### PR DESCRIPTION
  ## What changed

  This PR includes two fixes:

  1. **Compile fix in DAGCNFSimplifier**
     - Replaced unqualified `size_t` with `std::size_t` in `src/model/
  DAGCNFSimplifier.h`.
     - Reason: without `std::`, compilation can fail on stricter toolchains.

  2. **AIG generation consistency fix**
     - Updated `btor2/btorasaig.py` to remove `-a` when invoking `btor2aiger`, while
  keeping the output file as `.aig`.
     - Reason: with `-a`, output is not re-encoded, which may be incompatible with
  downstream tools (e.g. `certifaiger`).

  ## Commits

  - `bb5b1e7` fix: use std::size_t in DAGCNFSimplifier
  - `f0f208e` fix: generate binary .aig in btorasaig